### PR TITLE
tree node insertion fix

### DIFF
--- a/stree/multi/mtree.go
+++ b/stree/multi/mtree.go
@@ -160,10 +160,14 @@ func (t *mtree) Tree2Array() []SegmentOverlap {
 func (t *mtree) insertNodes(endpoint []int, level int) *mnode {
 	var n *mnode
 	//fmt.Printf("Level: %d\n", level)
-	if len(endpoint) == 2 {
+	if len(endpoint) == 1 {
+		n = &mnode{segment: Segment{endpoint[0], endpoint[0]}}
+		n.left = nil
+		n.right = nil
+	} else if len(endpoint) == 2 {
 		n = &mnode{segment: Segment{endpoint[0], endpoint[1]}}
 		if endpoint[1] != t.max {
-			n.left = &mnode{segment: Segment{endpoint[0], endpoint[1]}}
+			n.left = &mnode{segment: Segment{endpoint[0], endpoint[0]}}
 			n.right = &mnode{segment: Segment{endpoint[1], endpoint[1]}}
 		}
 	} else {
@@ -172,10 +176,10 @@ func (t *mtree) insertNodes(endpoint []int, level int) *mnode {
 		level++
 		if level == P_LEVEL && !t.single {
 			t.insertNodesAsync(&n.left, endpoint[:center+1], level)
-			t.insertNodesAsync(&n.right, endpoint[center:], level)
+			t.insertNodesAsync(&n.right, endpoint[center+1:], level)
 		} else {
 			n.left = t.insertNodes(endpoint[:center+1], level)
-			n.right = t.insertNodes(endpoint[center:], level)
+			n.right = t.insertNodes(endpoint[center+1:], level)
 		}
 	}
 	return n

--- a/stree/multi/mtree_test.go
+++ b/stree/multi/mtree_test.go
@@ -89,6 +89,51 @@ func TestMinimalTree(t *testing.T) {
 	}
 }
 
+func TestMinimalTree2(t *testing.T) {
+	tree := NewTree()
+	tree.Push(1, 1)
+	tree.BuildTree()
+	if result := tree.Query(1, 1); len(result) != 1 {
+		t.Errorf("fail query minimal tree for (1, 1)")
+	}
+	if result := tree.Query(1, 2); len(result) != 1 {
+		t.Errorf("fail query minimal tree for (1, 2)")
+	}
+	if result := tree.Query(2, 3); len(result) != 0 {
+		t.Errorf("fail query minimal tree for (2, 3)")
+	}
+}
+
+func TestNormalTree(t *testing.T) {
+	tree := NewTree()
+	tree.Push(1, 1)
+	tree.Push(2, 3)
+	tree.Push(5, 7)
+	tree.Push(4, 6)
+	tree.Push(6, 9)
+	tree.BuildTree()
+	if result := tree.Query(3, 5); len(result) != 3 {
+		t.Errorf("fail query multiple tree for (3, 5)")
+	}
+	qvalid := map[int]int{
+		0: 0,
+		1: 1,
+		2: 1,
+		3: 1,
+		4: 1,
+		5: 2,
+		6: 3,
+		7: 2,
+		8: 1,
+		9: 1,
+	}
+	for i := 0; i <= 9; i++ {
+		if result := tree.Query(i, i); len(result) != qvalid[i] {
+			t.Errorf("fail query multiple tree for (%d, %d)", i, i)
+		}
+	}
+}
+
 func BenchmarkSimple(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tree := NewMTree()

--- a/stree/stree.go
+++ b/stree/stree.go
@@ -191,17 +191,21 @@ func Dedup(sl []int) []int {
 // insertNodes builds tree structure from given endpoints
 func (t *stree) insertNodes(endpoint []int) *node {
 	var n *node
-	if len(endpoint) == 2 {
+	if len(endpoint) == 1 {
+		n = &node{segment: Segment{endpoint[0], endpoint[0]}}
+		n.left = nil
+		n.right = nil
+	} else if len(endpoint) == 2 {
 		n = &node{segment: Segment{endpoint[0], endpoint[1]}}
 		if endpoint[1] != t.max {
-			n.left = &node{segment: Segment{endpoint[0], endpoint[1]}}
+			n.left = &node{segment: Segment{endpoint[0], endpoint[0]}}
 			n.right = &node{segment: Segment{endpoint[1], endpoint[1]}}
 		}
 	} else {
 		n = &node{segment: Segment{endpoint[0], endpoint[len(endpoint)-1]}}
 		center := len(endpoint) / 2
 		n.left = t.insertNodes(endpoint[:center+1])
-		n.right = t.insertNodes(endpoint[center:])
+		n.right = t.insertNodes(endpoint[center+1:])
 	}
 	return n
 }

--- a/stree/stree_test.go
+++ b/stree/stree_test.go
@@ -69,6 +69,51 @@ func TestMinimalTree(t *testing.T) {
 	}
 }
 
+func TestMinimalTree2(t *testing.T) {
+	tree := NewTree()
+	tree.Push(1, 1)
+	tree.BuildTree()
+	if result := tree.Query(1, 1); len(result) != 1 {
+		t.Errorf("fail query minimal tree for (1, 1)")
+	}
+	if result := tree.Query(1, 2); len(result) != 1 {
+		t.Errorf("fail query minimal tree for (1, 2)")
+	}
+	if result := tree.Query(2, 3); len(result) != 0 {
+		t.Errorf("fail query minimal tree for (2, 3)")
+	}
+}
+
+func TestNormalTree(t *testing.T) {
+	tree := NewTree()
+	tree.Push(1, 1)
+	tree.Push(2, 3)
+	tree.Push(5, 7)
+	tree.Push(4, 6)
+	tree.Push(6, 9)
+	tree.BuildTree()
+	if result := tree.Query(3, 5); len(result) != 3 {
+		t.Errorf("fail query multiple tree for (3, 5)")
+	}
+	qvalid := map[int]int{
+		0: 0,
+		1: 1,
+		2: 1,
+		3: 1,
+		4: 1,
+		5: 2,
+		6: 3,
+		7: 2,
+		8: 1,
+		9: 1,
+	}
+	for i := 0; i <= 9; i++ {
+		if result := tree.Query(i, i); len(result) != qvalid[i] {
+			t.Errorf("fail query multiple tree for (%d, %d)", i, i)
+		}
+	}
+}
+
 func BenchmarkSimple(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		tree := NewTree()


### PR DESCRIPTION
The stree insertNode method has some bug. For example if we push only one inteval (1, 1) into the tree stack, the <code>insertNodes</code> will runs into a dead loop in the else case (len(endpoint) is always 1, center is 0)

```
func (t *stree) insertNodes(endpoint []int) *node {
    var n *node
    if len(endpoint) == 2 {
        n = &node{segment: Segment{endpoint[0], endpoint[1]}}
        if endpoint[1] != t.max {
            n.left = &node{segment: Segment{endpoint[0], endpoint[1]}}
            n.right = &node{segment: Segment{endpoint[1], endpoint[1]}}
        }
    } else {
        n = &node{segment: Segment{endpoint[0], endpoint[len(endpoint)-1]}}
        center := len(endpoint) / 2
        n.left = t.insertNodes(endpoint[:center+1])
        n.right = t.insertNodes(endpoint[center:])
    }
    return n
}
```

Besides, the covers of <code>left child</code> and <code>right child</code> of a certain parent with no intersection may be better. which means a node with segment of (1,3) will have a left child with segment (1,2) and right child with segment (3,3), the node (1,2) has a left child and a right child too.

```
      (1,3)
      /  \
   (1,2)  (3,3)
   /  \
(1,1) (2,2)
```
