### PR TITLE
Fixed unbalenced tree creation

### DIFF
--- a/stree/stree.go
+++ b/stree/stree.go
@@ -195,17 +195,11 @@ func (t *stree) insertNodes(endpoint []int) *node {
 		n = &node{segment: Segment{endpoint[0], endpoint[0]}}
 		n.left = nil
 		n.right = nil
-	} else if len(endpoint) == 2 {
-		n = &node{segment: Segment{endpoint[0], endpoint[1]}}
-		if endpoint[1] != t.max {
-			n.left = &node{segment: Segment{endpoint[0], endpoint[0]}}
-			n.right = &node{segment: Segment{endpoint[1], endpoint[1]}}
-		}
 	} else {
 		n = &node{segment: Segment{endpoint[0], endpoint[len(endpoint)-1]}}
 		center := len(endpoint) / 2
-		n.left = t.insertNodes(endpoint[:center+1])
-		n.right = t.insertNodes(endpoint[center+1:])
+		n.left = t.insertNodes(endpoint[:center])
+		n.right = t.insertNodes(endpoint[center:])
 	}
 	return n
 }


### PR DESCRIPTION
- Removed offset of node insertion to prevent unbalanced trees
- Removed special case for 2 remaining endpoints in `insertNodes` to ensure leafs get created properly

This seems to fix corner cases where some intervals were not found. The algorithm is now more similar to the description in the [Wikipedia article](http://en.wikipedia.org/wiki/Segment_tree).

I have little experience with segment trees as I do not have a computer science background, so it would be great to have the logic checked by someone before accepting this PR.
