### PR TITLE
Made stree behave like a proper segment tree

### DIFF
--- a/stree/stree.go
+++ b/stree/stree.go
@@ -184,7 +184,7 @@ func Dedup(sl []int) []int {
 // elementaryIntervals creates a slice of elementary intervals
 // from a sorted slice of endpoints
 // Input: [p1, p2, ..., pn]
-// Output: [{p1 : p2}, {p2 : p2},... , {pn : pn}]
+// Output: [{p1 : p1}, {p1 : p2}, {p2 : p2},... , {pn : pn}]
 func elementaryIntervals(endpoints []int) []Segment {
 	if len(endpoints) == 1 {
 		return []Segment{Segment{endpoints[0], endpoints[0]}}

--- a/stree/stree_test.go
+++ b/stree/stree_test.go
@@ -237,7 +237,7 @@ func BenchmarkInsertNodes100000(b *testing.B) {
 		endpoint, tree.min, tree.max = Endpoints(tree.base)
 		//fmt.Println(len(endpoint))
 		b.StartTimer()
-		tree.root = tree.insertNodes(endpoint)
+		tree.root = tree.insertNodes(elementaryIntervals(endpoint))
 	}
 }
 
@@ -248,7 +248,7 @@ func BenchmarkInsertIntervals100000(b *testing.B) {
 		pushRandom(tree, 100000)
 		var endpoint []int
 		endpoint, tree.min, tree.max = Endpoints(tree.base)
-		tree.root = tree.insertNodes(endpoint)
+		tree.root = tree.insertNodes(elementaryIntervals(endpoint))
 		b.StartTimer()
 		for i := range tree.base {
 			insertInterval(tree.root, &tree.base[i])


### PR DESCRIPTION
I adjusted the implementation of the segment tree to follow the algorithm as described in chapter 10.3 of [Computational Geometry: Algorithms and Applications](http://www.cs.uu.nl/geobook/) rev. 3.

This makes it possible to successfully perform stabbing queries on the tree when there are overlapping segments.

Note that I did not change anything in the paralel implementation (mtree).
